### PR TITLE
handle samtools typo fix

### DIFF
--- a/crimson/flagstat.py
+++ b/crimson/flagstat.py
@@ -24,7 +24,7 @@ _MAX_SIZE = 1024 * 10
 _RE_TOTAL = re.compile(r"(\d+) \+ (\d+) in total")
 _RE_DUPLICATES = re.compile(r"(\d+) \+ (\d+) duplicates")
 _RE_SECONDARY = re.compile(r"(\d+) \+ (\d+) secondary")
-_RE_SUPPLIMENTARY = re.compile(r"(\d+) \+ (\d+) supplimentary")
+_RE_SUPPLEMENTARY = re.compile(r"(\d+) \+ (\d+) suppl[ie]mentary")
 _RE_MAPPED = re.compile(r"(\d+) \+ (\d+) mapped ")
 _RE_PAIRED_SEQ = re.compile(r"(\d+) \+ (\d+) paired in ")
 _RE_READ1 = re.compile(r"(\d+) \+ (\d+) read1")
@@ -73,7 +73,7 @@ def parse(in_data):
         ("total", f(_RE_TOTAL)),
         ("duplicates", f(_RE_DUPLICATES)),
         ("secondary", f(_RE_SECONDARY)),
-        ("supplimentary", f(_RE_SUPPLIMENTARY)),
+        ("supplementary", f(_RE_SUPPLEMENTARY)),
         ("mapped", f(_RE_MAPPED)),
         ("paired_sequencing", f(_RE_PAIRED_SEQ)),
         ("paired", f(_RE_PAIRED_BAM)),

--- a/tests/test_flagstat.py
+++ b/tests/test_flagstat.py
@@ -96,7 +96,7 @@ def test_flagstat_v11_01_exit_code(flagstat_v11_01):
 @pytest.mark.parametrize("attr, exp", [
     ("total", 71511),
     ("secondary", 122),
-    ("supplimentary", 0),
+    ("supplementary", 0),
     ("duplicates", 0),
     ("mapped", 71228),
     ("paired_sequencing", 71389),
@@ -115,7 +115,7 @@ def test_flagstat_v11_01_pass_qc(flagstat_v11_01, attr, exp):
 @pytest.mark.parametrize("attr, exp", [
     ("total", 0),
     ("secondary", 0),
-    ("supplimentary", 0),
+    ("supplementary", 0),
     ("duplicates", 0),
     ("mapped", 0),
     ("paired_sequencing", 0),


### PR DESCRIPTION
Looks like samtools eventually fixed the typo in the flagstat output (supplimentary vs supplementary) and thus newer files don't parse correctly. These changes accept either spelling and update the parsed dictionary to use the correct spelling. Not sure if it's the right move to update the spelling or not.